### PR TITLE
Add smooth nametag colour transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ value.
   revolutions per second.
 - **Fade Duration** (`0.30`): seconds taken for tags and icons to fade in or
   out. Set to `0` for instant changes.
+- **Colour Transition Duration** (`0.25`): seconds taken for the name-tag colour
+  to adjust when it changes. Set to `0` for instant changes.
 - **Enable Mic Pulse** (`true`): if enabled, the speaker icon scales with voice
   loudness.
 - **Min Scale** (`0.7`): scale multiplier when the player is silent or

--- a/WhoIsTalking/Mod.cs
+++ b/WhoIsTalking/Mod.cs
@@ -17,6 +17,7 @@ namespace WhoIsTalking
         public static ConfigEntry<bool> ShowThirdPersonTag;
         public static ConfigEntry<float> SpinnerSpeed;
         public static ConfigEntry<float> FadeTime;
+        public static ConfigEntry<float> ColourChangeTime;
 
         // live mic-pulse controls
         public static ConfigEntry<bool> MicPulse;
@@ -49,6 +50,9 @@ namespace WhoIsTalking
 
             FadeTime = Config.Bind("Settings", "Fade Duration", 0.30f,
                 "Seconds taken for tags/icons to fade in or out. Set to 0 for instant.");
+
+            ColourChangeTime = Config.Bind("Settings", "Colour Transition Duration", 0.25f,
+                "Seconds taken for the name-tag colour to adjust when it changes. Set to 0 for instant.");
 
             /*──────────────── Mic-pulse settings ───────────────────*/
             MicPulse = Config.Bind("Mic-Pulse", "Enable Mic Pulse", true,

--- a/WhoIsTalking/NameTagHandler.cs
+++ b/WhoIsTalking/NameTagHandler.cs
@@ -19,6 +19,7 @@ namespace WhoIsTalking
 
         Spinner FPSpeakerSpin, TPSpeakerSpin;
         Vector3 speakerBaseScale;               // original prefab scale
+        Color currentColour;
 
         /* -------- Photon refs -------- */
         public VRRig rig;
@@ -40,6 +41,8 @@ namespace WhoIsTalking
                 SetUpNameTag();
 
             GetInfo();                               // cache refs on first spawn
+
+            currentColour = ColourHandling();
         }
 
         void SetUpNameTag()
@@ -145,7 +148,10 @@ namespace WhoIsTalking
             {
                 FPSpeakerSpin.Speed = TPSpeakerSpin.Speed = Mod.SpinnerSpeed.Value;
 
-                Color baseCol = ColourHandling();
+                Color targetCol = ColourHandling();
+                float colourSpeed = (Mod.ColourChangeTime.Value > 0f) ?
+                                      Time.deltaTime / Mod.ColourChangeTime.Value : 1f;
+                currentColour = Color.Lerp(currentColour, targetCol, colourSpeed);
 
                 float dist = Vector3.Distance(transform.position, Camera.main.transform.position);
                 bool withinRange = dist <= Mod.ViewDistance.Value.ClampSafe(0, 10);
@@ -157,10 +163,10 @@ namespace WhoIsTalking
                 bool showTPIcon = showTPTag && speaking;
 
                 float fadeSpeed = (Mod.FadeTime.Value > 0f) ? 1f / Mod.FadeTime.Value : 1000f;
-                FadeRenderer(FPRend, showFPTag, baseCol, fadeSpeed);
-                FadeRenderer(FPSpeakerRend, showFPIcon, baseCol, fadeSpeed);
-                FadeRenderer(TPRend, showTPTag, baseCol, fadeSpeed);
-                FadeRenderer(TPSpeakerRend, showTPIcon, baseCol, fadeSpeed);
+                FadeRenderer(FPRend, showFPTag, currentColour, fadeSpeed);
+                FadeRenderer(FPSpeakerRend, showFPIcon, currentColour, fadeSpeed);
+                FadeRenderer(TPRend, showTPTag, currentColour, fadeSpeed);
+                FadeRenderer(TPSpeakerRend, showTPIcon, currentColour, fadeSpeed);
 
                 /*──── mic-pulse ────*/
                 if (Mod.MicPulse.Value)


### PR DESCRIPTION
## Summary
- make name-tag colour changes smooth via new config `ColourChangeTime`
- expose new option in mod config
- document the config item in README

## Testing
- `dotnet build WhoIsTalking.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fc9d198c08329b18509c44202af9a